### PR TITLE
syscall is added for raspbian

### DIFF
--- a/mmap_linux_arm32.go
+++ b/mmap_linux_arm32.go
@@ -1,0 +1,12 @@
+package gommap
+
+import "syscall"
+
+func mmap_syscall(addr, length, prot, flags, fd uintptr, offset int64) (uintptr, error) {
+	page := uintptr(offset / 4096)
+	if offset != int64(page)*4096 {
+		return 0, syscall.EINVAL
+	}
+	addr, _, err := syscall.Syscall6(syscall.SYS_MMAP2, addr, length, prot, flags, fd, page)
+	return addr, err
+}


### PR DESCRIPTION
I'm working with the book [Distributed Services in Go](https://pragprog.com/titles/tjgo/distributed-services-with-go/) and do that sometimes on an iPad with an attached Raspberry. Therefor I needed support for Linux on 32bit ARM.

I was not able to test because of `package launchpad.net/gocheck: unrecognized import path "launchpad.net/gocheck"` but the code from the book works ;) 