### PR TITLE
Fix issue where Sync was passing the wrong file handle.

### DIFF
--- a/gommap_windows_test.go
+++ b/gommap_windows_test.go
@@ -129,3 +129,12 @@ func (s *S) TestLock(c *C) {
 	err = mmap.Unlock()
 	c.Assert(err, IsNil)
 }
+
+func (s *S) TestSync(c *C) {
+	mmap, err := Map(s.file.Fd(), PROT_READ|PROT_WRITE, MAP_PRIVATE)
+	c.Assert(err, IsNil)
+	defer mmap.UnsafeUnmap()
+
+	err = mmap.Sync(MS_SYNC)
+	c.Assert(err, IsNil)
+}


### PR DESCRIPTION
Sync was returning an error when being called on any file.  This was a result of passing the wrong handle to FlushFileBuffers - it was passing the handle for the file mapping, rather than the handle for the underlying file.

Apparently nobody was testing the result from Sync previously as the file handle it was passing would never have worked.